### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ var filter = require('profanity-filter');
 filter.seed('profanity');
 ```
 
-###filter.debug()
+### filter.debug()
 
 Returns the dictionary, replacementMethod, and grawlixChars internal properties for debugging purposes.
 


### PR DESCRIPTION
It looks like github's markdown requires a space for h3.